### PR TITLE
Feature/circuit drawer

### DIFF
--- a/pyquest/core.pyx
+++ b/pyquest/core.pyx
@@ -985,5 +985,5 @@ cdef class Circuit(GlobalOperator):
         for k in range(self.c_operations.size()):
             (<BaseOperator>self.c_operations[k]).apply_to(c_register)
 
-    def draw(self):
-        draw_circuit(self)
+    def draw(self, theme="bw", filename=None):
+        draw_circuit(self, theme, filename)

--- a/pyquest/drawer.py
+++ b/pyquest/drawer.py
@@ -1,17 +1,17 @@
-'''
+"""
 A simple circuit drawer, rendering in matplotlib.
 
 The bottom qubit is index 0, and all qubits from 0
-to the maximum targeted/controlled upon in the 
+to the maximum targeted/controlled upon in the
 circuit are rendered. Circuits are rendered as
 compactly as possible without commutation. The main
-function draw_circuit() accepts a pyQuEST Circuit 
+function draw_circuit() accepts a pyQuEST Circuit
 or a list of pyQuEST operators, and spawns a new
 matplotlib window.
 
 Quirks:
     - multi-target gates acting upon non-contiguous
-      qubits are drawn as a column of one-target 
+      qubits are drawn as a column of one-target
       gates connected by vertical lines (similar to
       how control qubits are rendered).
     - operators without explicit target qubits are
@@ -26,7 +26,7 @@ Quirks:
     - initialisations are drawn as all-target gates
       with dotted borders.
 
-The algorithm is basic; the circuit canvas is 
+The algorithm is basic; the circuit canvas is
 partitioned into a (#qubits x #depth) grid and
 each gate is assigned a column index therein. This
 is chosen as the leftmost (smallest index) column
@@ -36,7 +36,7 @@ Note that vertical connectors of a gate (e.g. the
 line between target and control qubits) occupy
 grid squares, but do not prevent subsequent gates
 from being placed left of them. Implementing this
-is easy; we track the rightmost targeted column 
+is easy; we track the rightmost targeted column
 of each qubit (we can never place new gates left of
 this), and also the columns to the right of this
 which are occluded (but not targeted) by vertical
@@ -44,8 +44,7 @@ connectors.
 
 @author Tyson Jones
 @date June 2024
-'''
-
+"""
 
 from operator import itemgetter
 from itertools import groupby
@@ -54,10 +53,8 @@ from statistics import mean
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
 import matplotlib.lines as mlines
-from matplotlib import colormaps
 
 # all concrete classes herein are drawable
-import numpy as np
 from pyquest.gates import *
 from pyquest.unitaries import *
 from pyquest.operators import *
@@ -65,12 +62,10 @@ from pyquest.decoherence import *
 from pyquest.initialisations import *
 
 
-
-'''
+"""
 TODO:
     - type hints + docstrings
-'''
-
+"""
 
 
 # visual order of graphic constituents (lower is occluded)
@@ -89,39 +84,40 @@ class layer:
     GATE_BODY = 2
 
 
-
 # size constants relative to the 1x1 gate grid
 class size:
 
     # minimum padding between circuit graphic and maptlotlib window
-    PLOT_PADDING = .1
+    PLOT_PADDING = 0.1
 
     # padding between gate's grid space and its gate body
-    GATE_RECTANGLE_NEG_PADDING = .1
+    GATE_RECTANGLE_NEG_PADDING = 0.1
 
     # radius of circle upon control qubits, and phase gate targets
-    CONTROL_CIRCLE_RADIUS = .1
+    CONTROL_CIRCLE_RADIUS = 0.1
 
     # radius of circle upon CX and CCX target qubits
-    TARGET_CIRCLE_RADIUS = .2
+    TARGET_CIRCLE_RADIUS = 0.2
 
 
 # class holding colors logic
 colors = None
+
+
 class Colors:
     themes = {
         "qm": {
-            "fig_color": "#2D2E44", # dark blue
+            "fig_color": "#2D2E44",  # dark blue
             "gate_edge_color": "white",
-            "gate_face_color": "#ff4342", # coral
+            "gate_face_color": "#ff4342",  # coral
             "vertical_connector_color": "white",
             "control_qubit_color": "white",
             "qubit_stave_color": "white",
             "label_color": "white",
-            "decoherence_color" : "blue",
-            "initialisations_color" : "blue",
-            "phase_gate_color" : "#ff4342",
-            "meas_gate_color" : "#03a0b5" # teal
+            "decoherence_color": "blue",
+            "initialisations_color": "blue",
+            "phase_gate_color": "#ff4342",
+            "meas_gate_color": "#03a0b5",  # teal
         },
         "dark": {
             "fig_color": "black",
@@ -131,10 +127,10 @@ class Colors:
             "control_qubit_color": "white",
             "qubit_stave_color": "white",
             "label_color": "white",
-            "decoherence_color" : "black",
-            "initialisations_color" : "black",
-            "phase_gate_color" : "white",
-            "meas_gate_color" : "black"
+            "decoherence_color": "black",
+            "initialisations_color": "black",
+            "phase_gate_color": "white",
+            "meas_gate_color": "black",
         },
         "bw": {
             "fig_color": "white",
@@ -144,11 +140,11 @@ class Colors:
             "control_qubit_color": "black",
             "qubit_stave_color": "lightgray",
             "label_color": "black",
-            "decoherence_color" : "white",
-            "initialisations_color" : "white",
-            "phase_gate_color" : "black",
-            "meas_gate_color" : "white"
-        }
+            "decoherence_color": "white",
+            "initialisations_color": "white",
+            "phase_gate_color": "black",
+            "meas_gate_color": "white",
+        },
     }
 
     def __init__(self, theme="bw"):
@@ -165,16 +161,16 @@ class Colors:
 
         if hasattr(pyquest.decoherence, type(gate).__name__):
             return self.colors["decoherence_color"]
-        
+
         elif hasattr(pyquest.initialisations, type(gate).__name__):
             return self.colors["initialisations_color"]
-        
+
         elif isinstance(gate, Phase):
             return self.colors["phase_gate_color"]
-        
+
         elif isinstance(gate, M):
             return self.colors["meas_gate_color"]
-        
+
         else:
             return self.colors["gate_face_color"]
 
@@ -183,7 +179,7 @@ class Colors:
 
     def get_control_qubit_color(self):
         return self.colors["control_qubit_color"]
-    
+
     def get_anticontrol_qubit_color(self):
         return self.colors["fig_color"]
 
@@ -194,13 +190,12 @@ class Colors:
         return self.colors["label_color"]
 
 
-
-'''
+"""
 Logic for deciding gate placement, which...
     - positions all gates within an integer grid by deciding each gate's column
     - assigns gates as far left as is possible without commuting existing gates
     - does not allow gates to coincide with vertical connectors of other gates
-'''
+"""
 
 
 def has_explicit_targets(gate):
@@ -236,15 +231,13 @@ def get_operated_qubits(gate, num_qubits):
 def get_num_qubits(gates):
 
     # find the biggest indexed target/control qubit among explicitly-targeted gates
-    return 1 + max(
-        max([*g.targets, *g.controls]) 
-        for g in gates if has_explicit_targets(g))
+    return 1 + max(max([*g.targets, *g.controls]) for g in gates if has_explicit_targets(g))
 
 
 def get_gate_column(gate_qubits, columns_of_last_target, columns_occluded_by_connectors):
 
     # qubits spanned by connectors between targets & controls
-    gate_range = list(range(min(gate_qubits), max(gate_qubits)+1))
+    gate_range = list(range(min(gate_qubits), max(gate_qubits) + 1))
 
     # initial choice is the leftmost un-targeted column
     column = 1 + max(columns_of_last_target[q] for q in gate_range)
@@ -265,10 +258,10 @@ def get_circuit_columns(gates):
     num_qubits = get_num_qubits(gates)
 
     # {qubit index: column}
-    columns_of_last_target = {i:-1 for i in range(num_qubits)}
+    columns_of_last_target = {i: -1 for i in range(num_qubits)}
 
     # {qubit index: [columns]}
-    columns_occluded_by_connectors = {i:[] for i in range(num_qubits)}
+    columns_occluded_by_connectors = {i: [] for i in range(num_qubits)}
 
     for gate in gates:
 
@@ -276,10 +269,12 @@ def get_circuit_columns(gates):
         gate_qubits = get_operated_qubits(gate, num_qubits)
 
         # there must be room for all qubits between those explicitly targeted, for connectors
-        gate_range = (min(gate_qubits), max(gate_qubits)+1)
+        gate_range = (min(gate_qubits), max(gate_qubits) + 1)
 
         # find the leftmost column which fits the gate
-        gate_column = get_gate_column(gate_qubits, columns_of_last_target, columns_occluded_by_connectors)
+        gate_column = get_gate_column(
+            gate_qubits, columns_of_last_target, columns_occluded_by_connectors
+        )
         gate_columns.append(gate_column)
 
         # prevent subsequent gates from commuting left of this gate
@@ -292,57 +287,56 @@ def get_circuit_columns(gates):
 
         # unnecessary memory cleanup; delete redundant vertical connectors left of targets
         for q in range(*gate_range):
-            columns_occluded_by_connectors[q] = [c 
-                for c in columns_occluded_by_connectors[q] 
-                if c > columns_of_last_target[q]]
+            columns_occluded_by_connectors[q] = [
+                c for c in columns_occluded_by_connectors[q] if c > columns_of_last_target[q]
+            ]
 
     # return one column per gate
     return gate_columns
 
 
-
-'''
+"""
 Visual gate styling
     - in matplotlib 3.8+, colours can be in a tuple with an alpha value,
       e.g. ('green', 0.3). We don't make use of this below
-'''
+"""
 
 
 def get_gate_label(gate):
 
     # all channels get abbreviated
     if isinstance(gate, Damping):
-        return 'γ'
+        return "γ"
     if isinstance(gate, Dephasing):
-        return 'φ'
+        return "φ"
     if isinstance(gate, Depolarising):
-        return 'Δ'
+        return "Δ"
     if isinstance(gate, KrausMap):
-        return 'K'
+        return "K"
     if isinstance(gate, PauliNoise):
-        return 'σ'
+        return "σ"
     if isinstance(gate, MixDensityMatrix):
-        return 'ρ'
+        return "ρ"
 
     # all initialisations get abbreviated
     if isinstance(gate, ZeroState):
-        return '0'
+        return "0"
     if isinstance(gate, BlankState):
-        return '∅'
+        return "∅"
     if isinstance(gate, ClassicalState):
-        return 'i'
+        return "i"
     if isinstance(gate, PlusState):
-        return '+'
+        return "+"
     if isinstance(gate, PureState):
-        return 'ψ'
+        return "ψ"
 
     # compactly specified unitaries are identical to general unitaries
     if isinstance(gate, CompactU):
-        return 'U'
+        return "U"
 
     # rotations around vector v look like Rx,Ry,Rz
     if isinstance(gate, RotateAroundAxis):
-        return 'Rv'
+        return "Rv"
 
     # some gates have no labels
     if isinstance(gate, Swap):
@@ -353,8 +347,9 @@ def get_gate_label(gate):
     # generic gates use their class name
     return type(gate).__name__
 
+
 def get_measure_symbol(gate, rect):
-    
+
     # calculate the center, height, and width of the rectangle
     x, y = (mean(x[i] for x in rect) for i in [0, 1])
     h, w = ((rect[2][i] - rect[0][i]) / len(gate.targets) for i in [0, 1])
@@ -370,7 +365,7 @@ def get_measure_symbol(gate, rect):
         fill=False,
         linewidth=1.5,
         color=colors.get_label_color(),
-        zorder=layer.GATE_BODY        
+        zorder=layer.GATE_BODY,
     )
 
     # create the line object
@@ -384,6 +379,7 @@ def get_measure_symbol(gate, rect):
 
     # Return both objects as a tuple
     return arc, line
+
 
 def get_gate_rect_style(gate):
 
@@ -399,7 +395,7 @@ def get_gate_rect_style(gate):
     return "solid"
 
 
-'''
+"""
 Logic for producing graphics, which...
     - draws phase and control qubits as circles
     - makes decoherence channel borders dashed
@@ -407,55 +403,55 @@ Logic for producing graphics, which...
     - labels gates with concise strings
     - merges gate bodies which target adjacent qubits
     - draws target bullseye for CX and CXX
-'''
+"""
 
 
 def get_grouped_consecutive_items(nums):
 
     # [1,2,4,5,6] -> [(1,2), (4,5,6)]
     indAndNums = enumerate(sorted(nums))
-    for _, group in groupby(indAndNums, lambda x:x[0]-x[1]):
+    for _, group in groupby(indAndNums, lambda x: x[0] - x[1]):
         yield list(map(itemgetter(1), group))
 
 
 def get_gate_graphic_components(gate, column, num_qubits):
 
     # graphics consist of vertical connector lines, control circles, and gate body rectangles
-    lines = []        # item = [(x0,y0), (x1,y1)]
-    circles = []      # item = (x0,y0)
-    rectangles = []   # item = [(x0,y0), (x0,y1), (x1,y1), (x1,y0)]
+    lines = []  # item = [(x0,y0), (x1,y1)]
+    circles = []  # item = (x0,y0)
+    rectangles = []  # item = [(x0,y0), (x0,y1), (x1,y1), (x1,y0)]
 
     # clarifying (in principle...) constants relative to 1x1 grid
-    qubits  = get_operated_qubits(gate, num_qubits)
-    pad     = size.GATE_RECTANGLE_NEG_PADDING
-    halfcol = .5
-    nextcol = column      + 1
-    midcol  = column      + halfcol
-    midtop  = max(qubits) + halfcol
-    midbot  = min(qubits) + halfcol
-    padcol  = column + pad
+    qubits = get_operated_qubits(gate, num_qubits)
+    pad = size.GATE_RECTANGLE_NEG_PADDING
+    halfcol = 0.5
+    nextcol = column + 1
+    midcol = column + halfcol
+    midtop = max(qubits) + halfcol
+    midbot = min(qubits) + halfcol
+    padcol = column + pad
     padnextcol = nextcol - pad
-    
+
     # note connector lines may be superfluous and occluded by rectangles
-    lines.append([ (midcol, midbot), (midcol, midtop) ]) # only one line needed
+    lines.append([(midcol, midbot), (midcol, midtop)])  # only one line needed
 
     # only attempt drawing controls if any exist (else .controls throws)
     if has_controls(gate):
-        circles += [(midcol, q+halfcol) for q in gate.controls]
+        circles += [(midcol, q + halfcol) for q in gate.controls]
 
     # explicitly targeted gates have adjacent targets merged into rectangles
     if has_explicit_targets(gate):
 
         for group in get_grouped_consecutive_items(gate.targets):
-            x0, y0 = padcol,     min(group)   + pad
-            x1, y1 = padnextcol, max(group)+1 - pad
-            rectangles.append([ (x0,y0), (x0,y1), (x1,y1), (x1,y0) ])
+            x0, y0 = padcol, min(group) + pad
+            x1, y1 = padnextcol, max(group) + 1 - pad
+            rectangles.append([(x0, y0), (x0, y1), (x1, y1), (x1, y0)])
 
     # whereas untargeted gates are assumed global and act on every qubit
     else:
-        x0, y0 = padcol,     0          + pad
+        x0, y0 = padcol, 0 + pad
         x1, y1 = padnextcol, num_qubits - pad
-        rectangles.append([ (x0,y0), (x0,y1), (x1,y1), (x1,y0) ])
+        rectangles.append([(x0, y0), (x0, y1), (x1, y1), (x1, y0)])
 
     # returned in order of increasing z-order
     return lines, circles, rectangles
@@ -464,42 +460,41 @@ def get_gate_graphic_components(gate, column, num_qubits):
 def draw_gate_body(gate, column, rectangles, plt, ax):
 
     # gate-specific styling for special operators
-    special_opts = {
-        'color':  colors.get_gate_face_color(gate),
-        'zorder': layer.GATE_BODY}
+    special_opts = {"color": colors.get_gate_face_color(gate), "zorder": layer.GATE_BODY}
 
     # SWAP gates ignore rectangles and draw X at every target
     if isinstance(gate, Swap):
         for q in gate.targets:
-            plt.scatter(column+.5, q+.5, marker='x', **special_opts)
+            plt.scatter(column + 0.5, q + 0.5, marker="x", **special_opts)
         return
 
     # Phase gates ignore rectangles and draw circle at every target
     if isinstance(gate, Phase):
         radius = size.CONTROL_CIRCLE_RADIUS
         for q in gate.targets:
-            ax.add_patch(plt.Circle((column+.5, q+.5), radius, **special_opts))
+            ax.add_patch(plt.Circle((column + 0.5, q + 0.5), radius, **special_opts))
         return
 
     # ordinary styling for rest
     other_opts = {
-        'linestyle': get_gate_rect_style(gate),
-        'edgecolor': colors.get_gate_edge_color(),
-        'facecolor': colors.get_gate_face_color(gate),
-        'zorder':    layer.GATE_BODY}
+        "linestyle": get_gate_rect_style(gate),
+        "edgecolor": colors.get_gate_edge_color(),
+        "facecolor": colors.get_gate_face_color(gate),
+        "zorder": layer.GATE_BODY,
+    }
 
-    # CX and CCX gates draw bullseyes rather than rectangles at every target
+    # CX and CCX gates draw bullseyes rather than rectangles at every target
     if isinstance(gate, X) and len(gate.controls) != 0:
         radius = size.TARGET_CIRCLE_RADIUS
         for q in gate.targets:
             # draw a circle
-            x,y  = column + .5, q + .5
-            ax.add_patch(plt.Circle((x,y), radius, linewidth=1.5, **other_opts))
+            x, y = column + 0.5, q + 0.5
+            ax.add_patch(plt.Circle((x, y), radius, linewidth=1.5, **other_opts))
             # draw the inner cross
             ax.plot([x - radius, x + radius], [y, y], color=colors.get_gate_edge_color())
             ax.plot([x, x], [y - radius, y + radius], color=colors.get_gate_edge_color())
         return
-    
+
     for rect in rectangles:
         ax.add_patch(plt.Polygon(rect, **other_opts))
 
@@ -513,15 +508,17 @@ def draw_gate_body(gate, column, rectangles, plt, ax):
             arc, line = get_measure_symbol(gate, rect)
             ax.add_patch(arc)
             ax.add_line(line)
-        
-        # SqrtSWAP gate uses mpl raw text
+
+        # SqrtSWAP gate uses mpl raw text
         elif isinstance(gate, SqrtSwap):
-            pos = (mean(x[i] for x in rect) for i in [0,1])
-            plt.text(*pos, s=r'$\sqrt{SWAP}$', va='center', ha='center', fontsize=8, color=label_color)        
+            pos = (mean(x[i] for x in rect) for i in [0, 1])
+            plt.text(
+                *pos, s=r"$\sqrt{SWAP}$", va="center", ha="center", fontsize=8, color=label_color
+            )
 
         else:
-            pos = (mean(x[i] for x in rect) for i in [0,1])
-            plt.text(*pos, s=label, va='center', ha='center', color=label_color)
+            pos = (mean(x[i] for x in rect) for i in [0, 1])
+            plt.text(*pos, s=label, va="center", ha="center", color=label_color)
 
     return
 
@@ -537,32 +534,42 @@ def draw_gate(gate, column, num_qubits, plt, ax):
         if line[0] == line[1]:
             continue
 
-        (a,b),(c,d) = line
+        (a, b), (c, d) = line
         plt.plot(
-            (a,c), (b,d), 
-            color=colors.get_vertical_connector_color(), 
-            zorder=layer.VERTICAL_CONNECTOR)
+            (a, c),
+            (b, d),
+            color=colors.get_vertical_connector_color(),
+            zorder=layer.VERTICAL_CONNECTOR,
+        )
 
     # Draw control dots
     for i, dot in enumerate(dots):
         control_color = (
-            colors.get_control_qubit_color() if not isinstance(gate, U) or not gate.control_pattern
-            else colors.get_control_qubit_color() if gate.control_pattern[i] == 1
-            else colors.get_anticontrol_qubit_color()
+            colors.get_control_qubit_color()
+            if not isinstance(gate, U) or not gate.control_pattern
+            else (
+                colors.get_control_qubit_color()
+                if gate.control_pattern[i] == 1
+                else colors.get_anticontrol_qubit_color()
+            )
         )
 
-        ax.add_patch(plt.Circle(
-            dot, size.CONTROL_CIRCLE_RADIUS, 
-            edgecolor=colors.get_gate_edge_color(),
-            facecolor=control_color,
-            linewidth=1.5,
-            zorder=layer.CONTROL_CIRCLE))
+        ax.add_patch(
+            plt.Circle(
+                dot,
+                size.CONTROL_CIRCLE_RADIUS,
+                edgecolor=colors.get_gate_edge_color(),
+                facecolor=control_color,
+                linewidth=1.5,
+                zorder=layer.CONTROL_CIRCLE,
+            )
+        )
 
     # draw the main body of the gate; possibly labelled rectangles, or bespoke symbols
     draw_gate_body(gate, column, rectangles, plt, ax)
 
 
-def draw_circuit(gates, theme = "bw", filename = None):
+def draw_circuit(gates, theme="bw", filename=None):
 
     # determine circuit layout
     gate_columns = get_circuit_columns(gates)
@@ -585,9 +592,11 @@ def draw_circuit(gates, theme = "bw", filename = None):
     # draw horizontal qubit stave
     for q in range(num_qubits):
         plt.plot(
-            [-.5, num_columns+.5], [q+.5, q+.5], 
-            color=colors.get_qubit_stave_color(), 
-            zorder=layer.QUBIT_STAVE)
+            [-0.5, num_columns + 0.5],
+            [q + 0.5, q + 0.5],
+            color=colors.get_qubit_stave_color(),
+            zorder=layer.QUBIT_STAVE,
+        )
 
     # draw each gate above stave
     for gate, column in zip(gates, gate_columns):
@@ -595,17 +604,17 @@ def draw_circuit(gates, theme = "bw", filename = None):
 
     # set plot range
     pad = size.PLOT_PADDING
-    ax.set_xlim(-.5 - pad, num_columns + pad +.5)
-    ax.set_ylim(-.5 - pad, num_qubits  + pad +.5)
+    ax.set_xlim(-0.5 - pad, num_columns + pad + 0.5)
+    ax.set_ylim(-0.5 - pad, num_qubits + pad + 0.5)
     # hide frame
-    ax.axis('off')
+    ax.axis("off")
 
     # force 1:1 aspect ratio (not crucial; fun to relax)
-    ax.set_aspect('equal')
+    ax.set_aspect("equal")
 
     # save the figure
     if filename:
-        plt.savefig(filename, bbox_inches='tight', dpi=300)
+        plt.savefig(filename, bbox_inches="tight", dpi=300)
 
     # render circuit immediately
     plt.show()

--- a/pyquest/drawer.py
+++ b/pyquest/drawer.py
@@ -103,48 +103,47 @@ class size:
 # class holding colors logic
 colors = None
 
-
 class Colors:
     themes = {
-        "qm": {
-            "fig_color": "#2D2E44",  # dark blue
-            "gate_edge_color": "white",
-            "gate_face_color": "#ff4342",  # coral
-            "vertical_connector_color": "white",
-            "control_qubit_color": "white",
-            "qubit_stave_color": "white",
-            "label_color": "white",
-            "decoherence_color": "blue",
-            "initialisations_color": "blue",
-            "phase_gate_color": "#ff4342",
-            "meas_gate_color": "#03a0b5",  # teal
+        "bw": {
+            "fig_color": "white",
+            "qubit_stave_color": "lightgray",
+            "vertical_connector_color": "gray",
+            "label_color": "black",
+            "initialisations_color": "white",
+            "decoherence_color": "white",
+            "operator_color": "white",
+            "gate_face_color": "white",
+            "gate_edge_color": "black",
+            "control_qubit_color": "black",
+            "meas_gate_color": "white"
         },
         "dark": {
             "fig_color": "black",
-            "gate_edge_color": "white",
-            "gate_face_color": "black",
-            "vertical_connector_color": "white",
-            "control_qubit_color": "white",
             "qubit_stave_color": "white",
+            "vertical_connector_color": "white",
             "label_color": "white",
-            "decoherence_color": "black",
             "initialisations_color": "black",
-            "phase_gate_color": "white",
-            "meas_gate_color": "black",
+            "decoherence_color": "black",
+            "operator_color": "black",
+            "gate_face_color": "black",
+            "gate_edge_color": "white",
+            "control_qubit_color": "white",
+            "meas_gate_color": "black"
         },
-        "bw": {
+        "qmt": {
             "fig_color": "white",
-            "gate_edge_color": "black",
-            "gate_face_color": "white",
-            "vertical_connector_color": "gray",
-            "control_qubit_color": "black",
-            "qubit_stave_color": "lightgray",
-            "label_color": "black",
-            "decoherence_color": "white",
-            "initialisations_color": "white",
-            "phase_gate_color": "black",
-            "meas_gate_color": "white",
-        },
+            "qubit_stave_color": "#2D2E44",
+            "vertical_connector_color": "#ff4342",
+            "label_color": "white",
+            "initialisations_color": "#2D2E44",
+            "decoherence_color": "gray",
+            "operator_color": "#3F1DF2",
+            "gate_face_color": "#ff4342",
+            "gate_edge_color": "#ff4342",
+            "control_qubit_color": "#ff4342",
+            "meas_gate_color": "#3F1DF2",
+        }
     }
 
     def __init__(self, theme="bw"):
@@ -154,40 +153,73 @@ class Colors:
     def get_fig_color(self):
         return self.colors["fig_color"]
 
-    def get_gate_edge_color(self):
-        return self.colors["gate_edge_color"]
+    def get_qubit_stave_color(self):
+        return self.colors["qubit_stave_color"]
+
+    def get_vertical_connector_color(self, gate):
+
+        if self.theme == "qmt":
+
+            if hasattr(pyquest.initialisations, type(gate).__name__):
+                return self.colors["initialisations_color"]
+
+            elif hasattr(pyquest.decoherence, type(gate).__name__):
+                return self.colors["decoherence_color"]
+
+            elif hasattr(pyquest.operators, type(gate).__name__):
+                return self.colors["operator_color"]
+        
+            elif isinstance(gate, M):
+                return self.colors["meas_gate_color"] 
+
+        return self.colors["vertical_connector_color"]
+
+    def get_label_color(self):
+        return self.colors["label_color"]
 
     def get_gate_face_color(self, gate):
 
-        if hasattr(pyquest.decoherence, type(gate).__name__):
-            return self.colors["decoherence_color"]
-
-        elif hasattr(pyquest.initialisations, type(gate).__name__):
+        if hasattr(pyquest.initialisations, type(gate).__name__):
             return self.colors["initialisations_color"]
 
+        elif hasattr(pyquest.decoherence, type(gate).__name__):
+            return self.colors["decoherence_color"]
+        
+        elif hasattr(pyquest.operators, type(gate).__name__):
+            return self.colors["operator_color"]
+
+        elif isinstance(gate, X) and len(gate.controls) != 0:
+            return self.colors["fig_color"]
+
         elif isinstance(gate, Phase):
-            return self.colors["phase_gate_color"]
+            return self.colors["control_qubit_color"]
 
         elif isinstance(gate, M):
             return self.colors["meas_gate_color"]
 
-        else:
-            return self.colors["gate_face_color"]
+        return self.colors["gate_face_color"]
 
-    def get_vertical_connector_color(self):
-        return self.colors["vertical_connector_color"]
+    def get_gate_edge_color(self, gate):
+
+        if hasattr(pyquest.decoherence, type(gate).__name__):
+            return self.colors["label_color"]
+
+        elif hasattr(pyquest.initialisations, type(gate).__name__):
+            return self.colors["label_color"]
+        
+        elif hasattr(pyquest.operators, type(gate).__name__) and self.theme == "qmt":
+            return self.colors["operator_color"]
+
+        elif isinstance(gate, X) and len(gate.controls) != 0:
+            return self.colors["control_qubit_color"]
+
+        elif isinstance(gate, M) and self.theme == "qmt":
+            return self.colors["meas_gate_color"]
+
+        return self.colors["gate_edge_color"]
 
     def get_control_qubit_color(self):
         return self.colors["control_qubit_color"]
-
-    def get_anticontrol_qubit_color(self):
-        return self.colors["fig_color"]
-
-    def get_qubit_stave_color(self):
-        return self.colors["qubit_stave_color"]
-
-    def get_label_color(self):
-        return self.colors["label_color"]
 
 
 """
@@ -478,7 +510,7 @@ def draw_gate_body(gate, column, rectangles, plt, ax):
     # ordinary styling for rest
     other_opts = {
         "linestyle": get_gate_rect_style(gate),
-        "edgecolor": colors.get_gate_edge_color(),
+        "edgecolor": colors.get_gate_edge_color(gate),
         "facecolor": colors.get_gate_face_color(gate),
         "zorder": layer.GATE_BODY,
     }
@@ -489,10 +521,10 @@ def draw_gate_body(gate, column, rectangles, plt, ax):
         for q in gate.targets:
             # draw a circle
             x, y = column + 0.5, q + 0.5
-            ax.add_patch(plt.Circle((x, y), radius, linewidth=1.5, **other_opts))
+            ax.add_patch(plt.Circle((x, y), radius, linewidth=1.8, **other_opts))
             # draw the inner cross
-            ax.plot([x - radius, x + radius], [y, y], color=colors.get_gate_edge_color())
-            ax.plot([x, x], [y - radius, y + radius], color=colors.get_gate_edge_color())
+            ax.plot([x - radius, x + radius], [y, y], color=colors.get_gate_edge_color(gate))
+            ax.plot([x, x], [y - radius, y + radius], color=colors.get_gate_edge_color(gate))
         return
 
     for rect in rectangles:
@@ -538,7 +570,7 @@ def draw_gate(gate, column, num_qubits, plt, ax):
         plt.plot(
             (a, c),
             (b, d),
-            color=colors.get_vertical_connector_color(),
+            color=colors.get_vertical_connector_color(gate),
             zorder=layer.VERTICAL_CONNECTOR,
         )
 
@@ -550,7 +582,7 @@ def draw_gate(gate, column, num_qubits, plt, ax):
             else (
                 colors.get_control_qubit_color()
                 if gate.control_pattern[i] == 1
-                else colors.get_anticontrol_qubit_color()
+                else colors.get_fig_color()
             )
         )
 
@@ -558,7 +590,7 @@ def draw_gate(gate, column, num_qubits, plt, ax):
             plt.Circle(
                 dot,
                 size.CONTROL_CIRCLE_RADIUS,
-                edgecolor=colors.get_gate_edge_color(),
+                edgecolor=colors.get_gate_edge_color(gate),
                 facecolor=control_color,
                 linewidth=1.5,
                 zorder=layer.CONTROL_CIRCLE,

--- a/pyquest/drawer.py
+++ b/pyquest/drawer.py
@@ -136,15 +136,16 @@ class Colors:
             "qubit_stave_color": "#2D2E44",
             "vertical_connector_color": "#ff4342",
             "label_color": "white",
-            "initialisations_color": "#2D2E44",
-            "decoherence_color": "gray",
-            "operator_color": "#3F1DF2",
+            "initialisations_color": "gray",
+            "decoherence_color": "#d91328",
+            "operator_color": "#ff4342",
             "gate_face_color": "#ff4342",
             "gate_edge_color": "#ff4342",
             "control_qubit_color": "#ff4342",
-            "meas_gate_color": "#3F1DF2",
+            "meas_gate_color": "#2D2E44",
         }
     }
+
 
     def __init__(self, theme="bw"):
         self.theme = theme
@@ -191,6 +192,9 @@ class Colors:
         elif isinstance(gate, X) and len(gate.controls) != 0:
             return self.colors["fig_color"]
 
+        elif isinstance(gate, Swap):
+            return self.colors["control_qubit_color"]
+        
         elif isinstance(gate, Phase):
             return self.colors["control_qubit_color"]
 


### PR DESCRIPTION
I have added a custom bullseye graphic for CNOT and CCNOT, a custom measurement graphic, empty dots for anticontrols, label for SqrtSWAP gate. Have also added the option to save the circuit by specifying a "filename". Finally, the user can now specify a "theme" for setting the colours of the circuit (default is boring black and white "bw", but "dark" and "qm" are also options).
![image](https://github.com/user-attachments/assets/f4249ae3-b47a-46e8-87d3-4e7a9de3ac18)
